### PR TITLE
Update jackson dependencies from 2.8.6 to 2.9.2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+1.1.3
+- Update jackson dependencies from 2.8.6 to 2.9.2
+
 1.1.2
   Support for Split Tags and full update endpoint.
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,8 @@
 NEWS
 
+1.1.3
+- Update jackson dependencies from 2.8.6 to 2.9.2
+
 1.1.2
   Support for Split Tags and full update endpoint.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.split.api</groupId>
     <artifactId>java-api</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <packaging>jar</packaging>
     <name>API Client</name>
     <description>Java SDK for Split's API</description>
@@ -71,12 +71,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.2</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Jackson 2.9 libraries are not backwards compatible with the old 2.8 ones, which has a great potential to cause a JAR hell when including the Split API dependency in a project that uses Jackson.